### PR TITLE
fix: return an empty array instead of an error for an empty friend list to #13 Issue

### DIFF
--- a/backend/src/routes/friends/friends.controller.ts
+++ b/backend/src/routes/friends/friends.controller.ts
@@ -18,9 +18,7 @@ async function getFriendsHandler(request: FastifyRequest, reply: FastifyReply) {
 		const requesterId = request.user!.id;
 		const friendships = await friendsService.findActiveFriends(request.server.prisma, requesterId);
 		if (!friendships || friendships.length === 0) {
-			return reply.code(404).send({
-				message: "No active friends found"
-			});
+			return reply.code(200).send([]);
 		}
 
 		const friends = friendships.map(f => {
@@ -136,9 +134,7 @@ async function getPendingRequestsHandler(request: FastifyRequest, reply: Fastify
 
 		const pending = await friendsService.findPendingRequests(request.server.prisma, userId)
 		if (!pending || pending.length === 0) {
-			return reply.code(404).send({
-                message: "No pending requests"
-            });
+			return reply.code(200).send([]);
 		}
 		const newArray = pending.map(f => ({
 			id: f.id,


### PR DESCRIPTION
There were a principal function wich was presenting troubles (getFriendsHandler) it was returning an 403 error as follows:

![before](https://github.com/user-attachments/assets/808ce33f-534a-4e9f-a7a8-88ee7840c245)

Then I have modified it to return an empty array as follows with a 200 code:
<img width="815" height="133" alt="image" src="https://github.com/user-attachments/assets/e5a6e58f-b03f-4bfd-af8e-ed3a8ad5591b" />

I found a similar Issue with the getPendingRequestsHandler function:

![before_2](https://github.com/user-attachments/assets/62e73043-45c5-48b1-99fe-547651840b4d)

I fix it too and now both are returning an empty:

<img width="809" height="158" alt="image" src="https://github.com/user-attachments/assets/bbaec3ba-cae0-4364-b5ca-d10815cb4085" />







